### PR TITLE
Add do_action() call after Taxonomy Order has been updated

### DIFF
--- a/yikes-custom-taxonomy-order.php
+++ b/yikes-custom-taxonomy-order.php
@@ -218,6 +218,9 @@ if ( ! class_exists( 'Yikes_Custom_Taxonomy_Order' ) ) {
 
 				update_term_meta( $order_data['term_id'], 'tax_position', ( (int) $order_data['order'] + (int) $base_index ) );
 			}
+
+			do_action( 'yikes_sto_taxonomy_order_updated', $taxonomy_ordering_data, $base_index );
+
 			wp_send_json_success();
 		}
 


### PR DESCRIPTION
https://wordpress.org/support/topic/add-action-to-after-taxonomy-order-is-saved/