### PR TITLE
add filter to enable/disable front-end ordering

### DIFF
--- a/yikes-custom-taxonomy-order.php
+++ b/yikes-custom-taxonomy-order.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'Yikes_Custom_Taxonomy_Order' ) ) {
 		 * Order the taxonomies on the front end.
 		 */
 		public function front_end_order_terms() {
-			if ( ! is_admin() ) {
+			if ( ! is_admin() && apply_filters( 'yikes_simple_taxonomy_ordering_front_end_order_terms', true ) ) {
 				add_filter( 'terms_clauses', array( $this, 'set_tax_order' ), 10, 3 );
 			}
 		}


### PR DESCRIPTION
This super-tiny enhancement adds a `yikes_simple_taxonomy_ordering_front_end_order_terms` filter which can be used to disable automatic front-end ordering. 

This preserves all existing behavior, but allows theme authors to fully disable automatic ordering with something like this:
```php
add_filter('yikes_simple_taxonomy_ordering_front_end_order_terms', '__return_false');
```

This seems a lot cleaner and safer than the current guidance of extracting the instance and disabling the filter. If the plugin is disabled, the filter does nothing.

Terms can still be explicitly ordered by adding `'meta_key' => 'tax_position'` and `'orderby' => 'meta_value_num'` to `get_terms()` query vars. 